### PR TITLE
Fix bugs in reference

### DIFF
--- a/src/main/java/com/plugin/frege/Frege.bnf
+++ b/src/main/java/com/plugin/frege/Frege.bnf
@@ -106,7 +106,7 @@ program ::= ((documentation VIRTUAL_END_DECL)* PROTECTED_MODIFIER? (strongPackag
 }
 packagePrefix ::= (packageToken DOT)*
 packageName ::= packagePrefix conidUsage
-private packageVarid ::= qualifier? qualifier? (extendedVarid | DATA | IMPORT | NATIVE | PACKAGE | MODULE | TYPE)
+private packageVarid ::= extendedVarid | DATA | IMPORT | NATIVE | PACKAGE | MODULE | TYPE
 packageToken ::= (packageVarid | CONID) {
     implements="com.plugin.frege.psi.FregeCompositeElement"
     mixin="com.plugin.frege.psi.mixin.imports.FregePackageTokenMixin"

--- a/src/main/java/com/plugin/frege/Frege.bnf
+++ b/src/main/java/com/plugin/frege/Frege.bnf
@@ -168,13 +168,13 @@ body ::= (documentation | topDecl) (VIRTUAL_END_DECL (documentation | topDecl))*
 topDecl ::= !<<eof>> (
               fixity
             | importDecl
-            | accessModifier? typeDecl
-            | accessModifier? dataDecl
-            | accessModifier? newtypeDecl
-            | accessModifier? nativeDataDecl
-            | accessModifier? classDecl
-            | accessModifier? instanceDecl
-            | accessModifier? deriveDecl
+            | typeDecl
+            | dataDecl
+            | newtypeDecl
+            | nativeDataDecl
+            | classDecl
+            | instanceDecl
+            | deriveDecl
             | nativeModule
             | decl) SEMICOLON? {
     pin=1
@@ -266,8 +266,8 @@ infixRule ::= INFIX | INFIXL | INFIXR
 
 
 /* Type Declarations */
-typeDecl ::= TYPE conidUsage typedVarid* EQUAL sigma {
-    pin=1
+typeDecl ::= accessModifier? TYPE conidUsage typedVarid* EQUAL sigma {
+    pin=2
     implements=["com.plugin.frege.psi.FregePsiClass"
                 "com.plugin.frege.psi.FregeTypeParametersHolder"]
     mixin="com.plugin.frege.psi.mixin.FregeTypeDeclMixin"
@@ -277,8 +277,8 @@ typeDecl ::= TYPE conidUsage typedVarid* EQUAL sigma {
 
 /* Class Declarations */
 // TODO take class name out of constraints. After that fix it in mixin!
-classDecl ::= (CLASS | INTERFACE) constraints ( DOUBLE_RIGHT_ARROW conidUsage typedVarid)?  whereSection? {
-    pin=1
+classDecl ::= accessModifier? (CLASS | INTERFACE) constraints ( DOUBLE_RIGHT_ARROW conidUsage typedVarid)?  whereSection? {
+    pin=2
     implements=["com.plugin.frege.psi.FregePsiClass"
                 "com.plugin.frege.psi.FregeTypeParametersHolder"]
     mixin="com.plugin.frege.psi.mixin.FregeClassDeclMixin"
@@ -287,8 +287,8 @@ classDecl ::= (CLASS | INTERFACE) constraints ( DOUBLE_RIGHT_ARROW conidUsage ty
 
 
 /* Instance Declarations */
-instanceDecl ::= INSTANCE (constraints DOUBLE_RIGHT_ARROW)? qConid typeApplications whereSection? {
-    pin=1
+instanceDecl ::= accessModifier? INSTANCE (constraints DOUBLE_RIGHT_ARROW)? qConid typeApplications whereSection? {
+    pin=2
     implements=["com.plugin.frege.psi.FregePsiClass"
                 "com.plugin.frege.psi.FregeTypeParametersHolder"]
     mixin="com.plugin.frege.psi.mixin.FregeInstanceDeclMixin"
@@ -297,16 +297,16 @@ instanceDecl ::= INSTANCE (constraints DOUBLE_RIGHT_ARROW)? qConid typeApplicati
 
 
 /* Derived Instances */
-deriveDecl ::= DERIVE conidUsage (constraints DOUBLE_RIGHT_ARROW)? typeApplications {
-    pin=1
+deriveDecl ::= accessModifier? DERIVE conidUsage (constraints DOUBLE_RIGHT_ARROW)? typeApplications {
+    pin=2
     implements="com.plugin.frege.psi.FregeTypeParametersHolder"
     mixin="com.plugin.frege.psi.mixin.FregeDeriveDeclMixin"
 }
 
 
 /* Data Declarations */
-dataDecl ::= ABSTRACT? DATA conidUsage typedVarid* EQUAL constructs whereSection? deriveDecl? documentation? {
-    pin=6
+dataDecl ::= accessModifier? ABSTRACT? DATA conidUsage typedVarid* EQUAL constructs whereSection? deriveDecl? documentation? {
+    pin=7
     implements=["com.plugin.frege.psi.FregePsiClass"
                 "com.plugin.frege.psi.FregeTypeParametersHolder"]
     mixin="com.plugin.frege.psi.mixin.FregeDataDeclMixin"
@@ -334,8 +334,8 @@ labelName ::= extendedVarid {
 }
 
 /* Newtype Declarations */
-newtypeDecl ::= ABSTRACT? NEWTYPE conidUsage typedVarid* EQUAL construct whereSection? {
-    pin=2
+newtypeDecl ::= accessModifier? ABSTRACT? NEWTYPE conidUsage typedVarid* EQUAL construct whereSection? {
+    pin=3
     implements=["com.plugin.frege.psi.FregePsiClass"
                 "com.plugin.frege.psi.FregeTypeParametersHolder"]
     mixin="com.plugin.frege.psi.mixin.FregeNewtypeDeclMixin"
@@ -344,8 +344,8 @@ newtypeDecl ::= ABSTRACT? NEWTYPE conidUsage typedVarid* EQUAL construct whereSe
 
 
 /* Native Data Declarations */
-nativeDataDecl ::= DATA conidUsage typedVarid* EQUAL (strongMutable|strongPure)? NATIVE nativeName nativeTypeApplications? whereSection? deriveDecl? {
-    pin=6
+nativeDataDecl ::= accessModifier? DATA conidUsage typedVarid* EQUAL (strongMutable|strongPure)? NATIVE nativeName nativeTypeApplications? whereSection? deriveDecl? {
+    pin=7
     implements=["com.plugin.frege.psi.FregePsiClass"
                 "com.plugin.frege.psi.FregeTypeParametersHolder"]
     mixin="com.plugin.frege.psi.mixin.FregeNativeDataDeclMixin"
@@ -357,8 +357,8 @@ nativeName ::= ((extendedVarid | CONID) DOT)* (extendedVarid | CONID | stringLit
 }
 
 /* Native module */
-nativeModule ::= NATIVE MODULE (TYPE typeApplications)? (CLASS <<commaSequence constraint>>)? WHERE LEFT_BRACE javaCode RIGHT_BRACE {
-    pin=2
+nativeModule ::= accessModifier? NATIVE MODULE (TYPE typeApplications)? (CLASS <<commaSequence constraint>>)? WHERE LEFT_BRACE javaCode RIGHT_BRACE {
+    pin=3
 }
 external javaCode ::= javaCodeParseExternal
 

--- a/src/main/kotlin/com/plugin/frege/inspections/FregeUnresolvedReferenceInspection.kt
+++ b/src/main/kotlin/com/plugin/frege/inspections/FregeUnresolvedReferenceInspection.kt
@@ -9,7 +9,7 @@ import com.plugin.frege.psi.FregeResolvableElement
 
 class FregeUnresolvedReferenceInspection : FregeLocalInspection() {
     override fun visitElement(element: FregeCompositeElement, holder: ProblemsHolder, isOnTheFly: Boolean) {
-        if (element !is FregeResolvableElement) {
+        if (element !is FregeResolvableElement || element.textLength == 0) {
             return
         }
 

--- a/src/main/kotlin/com/plugin/frege/psi/impl/FregePsiUtilImpl.kt
+++ b/src/main/kotlin/com/plugin/frege/psi/impl/FregePsiUtilImpl.kt
@@ -280,7 +280,26 @@ object FregePsiUtilImpl {
     /**
      * Checks if within children of [element] there is an PSI node of [type].
      */
+    @JvmStatic
     fun isElementTypeWithinChildren(element: PsiElement, type: IElementType): Boolean {
         return generateSequence({ element.firstChild }, { it.nextSibling }).any { it.elementType === type }
+    }
+
+    /**
+     * Required for navigation to modules from the standard library.
+     * According to the language rules, '`frege`' can be omitted in the imported package,
+     * provided if you replace the first letter in the next word with the upper-cased one.
+     *
+     * Example: 'frege.data.HashMap -> Data.HashMap'
+     *
+     * @return converted [packageName] to the package with the '`frege`' prefix
+     * or `null` if it's not possible ([packageName] is empty or the first letter is not upper-cased)
+     */
+    @JvmStatic
+    fun tryConvertToLibraryPackage(packageName: String): String? {
+        if (packageName.isEmpty() || !packageName.first().isUpperCase()) {
+            return null
+        }
+        return "frege.${packageName.first().lowercaseChar()}${packageName.substring(1)}"
     }
 }

--- a/src/main/kotlin/com/plugin/frege/psi/mixin/imports/FregePackageTokenMixin.kt
+++ b/src/main/kotlin/com/plugin/frege/psi/mixin/imports/FregePackageTokenMixin.kt
@@ -5,9 +5,11 @@ import com.intellij.openapi.util.TextRange
 import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiReference
+import com.intellij.util.containers.addIfNotNull
 import com.plugin.frege.psi.FregeElementFactory
 import com.plugin.frege.psi.FregePackagePrefix
 import com.plugin.frege.psi.impl.FregeCompositeElementImpl
+import com.plugin.frege.psi.impl.FregePsiUtilImpl
 import com.plugin.frege.resolve.FregeReferenceBase
 
 open class FregePackageTokenMixin(node: ASTNode) : FregeCompositeElementImpl(node) { // TODO implement psi package
@@ -17,8 +19,17 @@ open class FregePackageTokenMixin(node: ASTNode) : FregeCompositeElementImpl(nod
                 val packagePrefix = psiElement.parent as? FregePackagePrefix ?: return emptyList()
                 val packageText = packagePrefix.text
                 val qualifiedName = packageText.substring(0, psiElement.textRange.endOffset - parent.textOffset)
-                val resolvedPackage = JavaPsiFacade.getInstance(psiElement.project).findPackage(qualifiedName)
-                return if (resolvedPackage != null) listOf(resolvedPackage) else emptyList()
+                val results = mutableListOf<PsiElement>()
+                val psiFacade = JavaPsiFacade.getInstance(psiElement.project)
+                results.addIfNotNull(psiFacade.findPackage(qualifiedName))
+
+                if (results.isEmpty()) {
+                    val libraryPackage = FregePsiUtilImpl.tryConvertToLibraryPackage(qualifiedName)
+                    if (libraryPackage != null) {
+                        results.addIfNotNull(psiFacade.findPackage(libraryPackage))
+                    }
+                }
+                return results
             }
 
             override fun handleElementRename(name: String): PsiElement {


### PR DESCRIPTION
* Move access modifiers from top declarations into rules so fix resolving classes within current file
* Implement converting regular import to library package (packages with 'frege' prefix may omit 'frege' in importing)
* Fix bug with empty names in unresolved reference inspection